### PR TITLE
Fixing docs on memory required

### DIFF
--- a/docs/indexing.rst
+++ b/docs/indexing.rst
@@ -70,7 +70,7 @@ matrix and a pagerank vector in four steps:
 
 This slightly convoluted setup makes it possible to compute the
 adjacency matrix and pagerank from entire dumps on a machine with little
-memory (8GB).
+memory (32GB).
 
 Indexing for tagging
 --------------------


### PR DESCRIPTION
I needed > 16 GB main memory for `tapioca compile wikidata_graph.tsv` as well as `tapioca compute-pagerank wikidata_graph.npz`